### PR TITLE
Fix "project or solution file" error in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,6 +110,10 @@ install:
 
 ## Build Script ##
 
+# 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents
+# the "directory does not contain a project or solution file" error.
+build: false
+
 # Uses 'cargo test' to run tests. Alternatively, the project may call compiled programs directly or
 # perform other testing commands. Rust will automatically be placed in the PATH environment
 # variable.


### PR DESCRIPTION
Disabling Appveyor's built-in build step solves this error (since `cargo test` takes care of building for us).
